### PR TITLE
Clarify BarsInProgress reference index. Cumulative Delta Index Reference

### DIFF
--- a/AddOns/OrderFlowBot/OrderFlowBot.cs
+++ b/AddOns/OrderFlowBot/OrderFlowBot.cs
@@ -265,7 +265,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 _technicalLevels = new List<TechnicalLevels>
                 {
                     new TechnicalLevels(CurrentBars[0], RequiredTicksForBroken * TickSize)
-                    //new TechnicalLevels(CurrentBars[1], RequiredTicksForBroken * TickSize)
+                    //new TechnicalLevels(CurrentBars[2], RequiredTicksForBroken * TickSize)
                 };
 
                 _strategiesConfig = new StrategiesConfig();
@@ -292,7 +292,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 // Required for the cumulative delta bar
                 AddDataSeries(Data.BarsPeriodType.Tick, 1);
 
-                // Make sure to add the BarsInProgress for the additional data series
+                // Make sure to add the BarsInProgress for the additional data series. e.g. BarsInProgress = 2
                 // Make sure to add second TechnicalLevels instance for the list
                 //AddDataSeries(BarsPeriodType.Minute, 5);
             }


### PR DESCRIPTION
When adding an additional Technical level. A second data series is needed, in addition to the already added 1 tick data series.
A second data series increases index reference +1.  If a user needs technical levels on a longer time frame like the example. This data series would also be 2 or greater for any additional series added.