### PR TITLE
Fixed time range issue

### DIFF
--- a/NinjaTrader/Custom/AddOns/OrderFlowBot/OrderFlowBot.cs
+++ b/NinjaTrader/Custom/AddOns/OrderFlowBot/OrderFlowBot.cs
@@ -225,23 +225,9 @@ namespace NinjaTrader.NinjaScript.Strategies
                 SetConfigs();
                 SetMessagingConfigs();
 
-                // Validate TimeStart and TimeEnd
-                if (TimeStart.Length != 6 || TimeEnd.Length != 6 || !TimeStart.All(char.IsDigit) || !TimeEnd.All(char.IsDigit))
+                if (!ValidateTimeProperties())
                 {
-                    System.Windows.MessageBox.Show(
-                        "TimeStart and TimeEnd must each contain exactly 6 numeric characters HHMMSS.",
-                        "Invalid Time Configuration",
-                        System.Windows.MessageBoxButton.OK,
-                        System.Windows.MessageBoxImage.Warning
-                    );
-
-                    _servicesContainer.TradingService.HandleEnabledDisabledTriggered(false);
                     return;
-                }
-                else
-                {
-                    _parsedTimeStart = int.Parse(TimeStart);
-                    _parsedTimeEnd = int.Parse(TimeEnd);
                 }
 
                 // Data Series Index Mapping
@@ -503,6 +489,23 @@ namespace NinjaTrader.NinjaScript.Strategies
                     _userInterfaceEvents.DisableAllControls();
                 }
             }
+        }
+
+        private bool ValidateTimeProperties()
+        {
+            // Validate TimeStart and TimeEnd
+            if (TimeStart.Length != 6 || TimeEnd.Length != 6 || !TimeStart.All(char.IsDigit) || !TimeEnd.All(char.IsDigit))
+            {
+                System.Windows.MessageBox.Show(
+                    "TimeStart and TimeEnd must each contain exactly 6 numeric characters HHMMSS.",
+                    "Invalid Time Configuration",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Warning
+                );
+                _servicesContainer.TradingService.HandleEnabledDisabledTriggered(false);
+                return false;
+            }
+            return int.TryParse(TimeStart, out _parsedTimeStart) && int.TryParse(TimeEnd, out _parsedTimeEnd);
         }
 
         #endregion

--- a/NinjaTrader/Custom/AddOns/OrderFlowBot/OrderFlowBot.cs
+++ b/NinjaTrader/Custom/AddOns/OrderFlowBot/OrderFlowBot.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 #endregion
 
@@ -46,6 +47,8 @@ namespace NinjaTrader.NinjaScript.Strategies
         private bool _validTimeRange;
         private bool _timeStartChecked;
         private bool _timeEndChecked;
+        private int _parsedTimeStart;
+        private int _parsedTimeEnd;
 
         private Dictionary<string, int> _dataSeriesIndexMap;
 
@@ -78,11 +81,11 @@ namespace NinjaTrader.NinjaScript.Strategies
 
         [NinjaScriptProperty]
         [Display(Name = "Time Start", Description = "The allowed time to enable OFB.", Order = 6, GroupName = GroupConstants.GROUP_NAME_GENERAL)]
-        public int TimeStart { get; set; }
+        public string TimeStart { get; set; }
 
         [NinjaScriptProperty]
         [Display(Name = "Time End", Description = "The allowed time to disable and close positions for OFB.", Order = 7, GroupName = GroupConstants.GROUP_NAME_GENERAL)]
-        public int TimeEnd { get; set; }
+        public string TimeEnd { get; set; }
 
         #endregion
 
@@ -195,8 +198,8 @@ namespace NinjaTrader.NinjaScript.Strategies
                 DailyLossEnabled = false;
                 DailyLoss = 1000;
                 TimeEnabled = false;
-                TimeStart = 093000;
-                TimeEnd = 155500;
+                TimeStart = "093000";
+                TimeEnd = "155500";
 
                 BacktestEnabled = false;
                 BacktestStrategyName = "Stacked Imbalances";
@@ -221,6 +224,25 @@ namespace NinjaTrader.NinjaScript.Strategies
             {
                 SetConfigs();
                 SetMessagingConfigs();
+
+                // Validate TimeStart and TimeEnd
+                if (TimeStart.Length != 6 || TimeEnd.Length != 6 || !TimeStart.All(char.IsDigit) || !TimeEnd.All(char.IsDigit))
+                {
+                    System.Windows.MessageBox.Show(
+                        "TimeStart and TimeEnd must each contain exactly 6 numeric characters HHMMSS.",
+                        "Invalid Time Configuration",
+                        System.Windows.MessageBoxButton.OK,
+                        System.Windows.MessageBoxImage.Warning
+                    );
+
+                    _servicesContainer.TradingService.HandleEnabledDisabledTriggered(false);
+                    return;
+                }
+                else
+                {
+                    _parsedTimeStart = int.Parse(TimeStart);
+                    _parsedTimeEnd = int.Parse(TimeEnd);
+                }
 
                 // Data Series Index Mapping
                 _dataSeriesIndexMap = new Dictionary<string, int>
@@ -264,6 +286,7 @@ namespace NinjaTrader.NinjaScript.Strategies
 
                 _eventsContainer.EventManager.OnPrintMessage += HandlePrintMessage;
 
+                SetInitialDefaults();
                 InitializeStrategyManager();
 
                 if (Category != Category.Backtest)
@@ -285,13 +308,9 @@ namespace NinjaTrader.NinjaScript.Strategies
         protected override void OnBarUpdate()
         {
             // Ensure we have defaults at the start of the session across multiple sessions
-            if (Bars.IsFirstBarOfSession)
+            if (BarsInProgress == 0 && Bars?.IsFirstBarOfSession == true)
             {
-                _tradingEvents.ResetTriggeredTradingState();
-                _eventsContainer.StrategiesEvents.ResetStrategyData();
-                _validTimeRange = false;
-                _timeStartChecked = false;
-                _timeEndChecked = false;
+                SetInitialDefaults();
             }
 
             if (BarsInProgress == 0 && CurrentBars[0] < BarsRequiredToTrade)
@@ -369,6 +388,15 @@ namespace NinjaTrader.NinjaScript.Strategies
             }
         }
 
+        private void SetInitialDefaults()
+        {
+            _tradingEvents.ResetTriggeredTradingState();
+            _eventsContainer.StrategiesEvents.ResetStrategyData();
+            _validTimeRange = false;
+            _timeStartChecked = false;
+            _timeEndChecked = false;
+        }
+
         private void SetMessagingConfigs()
         {
             MessagingConfig.Instance.MarketEnvironment = MarketEnvironment;
@@ -433,7 +461,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 }
 
                 // Check if the end time is reached and disable the panel if needed
-                if (!_timeEndChecked && ToTime(Times[2][1]) >= TimeEnd)
+                if (!_timeEndChecked && ToTime(Times[2][1]) >= _parsedTimeEnd)
                 {
                     _timeEndChecked = true;
                     UpdateValidStartEndTimeUserInterface(false);
@@ -441,13 +469,8 @@ namespace NinjaTrader.NinjaScript.Strategies
             }
             else
             {
-                // If outside the valid range, ensure the panel is disabled
-                if (_timeStartChecked && !_timeEndChecked)
-                {
-                    _timeStartChecked = false;
-                    _timeEndChecked = true;
-                    UpdateValidStartEndTimeUserInterface(false);
-                }
+
+                UpdateValidStartEndTimeUserInterface(false);
             }
         }
 
@@ -460,7 +483,7 @@ namespace NinjaTrader.NinjaScript.Strategies
 
             var currentTime = ToTime(Times[2][1]);
 
-            return (currentTime >= TimeStart && currentTime <= TimeEnd);
+            return (currentTime >= _parsedTimeStart && currentTime <= _parsedTimeEnd);
         }
 
         private void UpdateValidStartEndTimeUserInterface(bool validStartEndTime)

--- a/NinjaTrader/Custom/AddOns/OrderFlowBot/UserInterfaces/Components/GridBase.cs
+++ b/NinjaTrader/Custom/AddOns/OrderFlowBot/UserInterfaces/Components/GridBase.cs
@@ -153,7 +153,7 @@ namespace NinjaTrader.Custom.AddOns.OrderFlowBot.UserInterfaces.Components
             else
             {
                 // Avoid blocking or potential recursion
-                Dispatcher.BeginInvoke(new Action(() => EnableControls(this)));
+                Dispatcher.BeginInvoke(new Action(() => DisableControls(this)));
             }
         }
 

--- a/NinjaTrader/Custom/AddOns/OrderFlowBot/UserInterfaces/Components/GridBase.cs
+++ b/NinjaTrader/Custom/AddOns/OrderFlowBot/UserInterfaces/Components/GridBase.cs
@@ -152,7 +152,8 @@ namespace NinjaTrader.Custom.AddOns.OrderFlowBot.UserInterfaces.Components
             }
             else
             {
-                Dispatcher.Invoke(() => DisableControls(this));
+                // Avoid blocking or potential recursion
+                Dispatcher.BeginInvoke(new Action(() => EnableControls(this)));
             }
         }
 
@@ -179,11 +180,13 @@ namespace NinjaTrader.Custom.AddOns.OrderFlowBot.UserInterfaces.Components
         {
             if (Dispatcher.CheckAccess())
             {
+                // Already on the UI thread, directly enable controls
                 EnableControls(this);
             }
             else
             {
-                Dispatcher.Invoke(() => EnableControls(this));
+                // Avoid blocking or potential recursion
+                Dispatcher.BeginInvoke(new Action(() => EnableControls(this)));
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ You can find the latest release at https://github.com/WaleeTheRobot/order-flow-b
 
 Sometimes NinjaTrader will complain about an import failed. You can just open the zip file from the release and copy the OrderFlowBot directory into the Add On directory on your computer after removing the previous OrderFlowBot directory. It's normally located at: `C:\Users\<username>\Documents\NinjaTrader 8\bin\Custom\AddOns`. Afterwards, open NinjaTrader and click `New` > `NinjaScript Editor`. Click the NinjaScript Editor and press `F5`. It'll take a few seconds and you'll hear a sound. The icon at the bottom left corner of it will disappear when it's done compiling. Close the NinjaScript Editor and you should be good to go.
 
+### Important Issues
+
+There seems to be an issue with NT not entering the OnBarUpdate method when the Enabled is selected in the strategies tab around the accounts and orders tabs. Checking the Enabled while initially loading seems to be the current workaround. This is happening in 8.1.4.0 and seems to persist if you downgrade back to 8.1.3.1.
+
 # Development
 
 Install System.Text.Json from Nugget in your IDE.
@@ -41,6 +45,7 @@ Install System.Text.Json from Nugget in your IDE.
 I've noticed NT having issues between compile and runtime loading dlls if you copy them over to the `Custom` directory or reference it somewhere else. The ones in the NT directory below should work. Reference those in NinjaScript Editor.
 
 `C:\Program Files\NinjaTrader 8\bin\System.Text.Json.dll`
+
 `C:\Program Files\NinjaTrader 8\bin\System.Memory.dll`
 
 ## Advance

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ Sometimes NinjaTrader will complain about an import failed. You can just open th
 
 # Development
 
-Install System.Text.Json from Nugget in your IDE. You may also have to add the missing dlls as references in the NinjaScript Editor. When prompted, they should be available at `Documents\NinjaTrader 8\bin\Custom\bin\Debug`.
+Install System.Text.Json from Nugget in your IDE.
+
+I've noticed NT having issues between compile and runtime loading dlls if you copy them over to the `Custom` directory or reference it somewhere else. The ones in the NT directory below should work. Reference those in NinjaScript Editor.
+
+`C:\Program Files\NinjaTrader 8\bin\System.Text.Json.dll`
+`C:\Program Files\NinjaTrader 8\bin\System.Memory.dll`
 
 ## Advance
 


### PR DESCRIPTION
- Converted the TimeStart and TimeEnd to a string to avoid the leading zero being stripped
- Added a message box if the TimeStart and TimeEnd are not in the correct format
- Fixed control panel display issue outside of time range
- Updated README to note the current NinjaTrader enable issue